### PR TITLE
[nrf noup] cmake: Fix multi-image

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ else()
 	)
 
   zephyr_link_libraries(
-    mbedtls_external
+    ${IMAGE}mbedtls_external
     -L${CONFIG_MBEDTLS_INSTALL_PATH}
     gcc
     )


### PR DESCRIPTION
Fix multi-image by image-ifying a symbol that should have been
image-ified.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>