### PR TITLE
DNM: Revert "[nrf noup] Re-apply downstream changes to mcumgr"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,11 @@ if(CONFIG_MBEDTLS)
 zephyr_interface_library_named(mbedTLS)
 
 if(CONFIG_MBEDTLS_BUILTIN)
-  target_compile_definitions(${IMAGE}mbedTLS INTERFACE
+  target_compile_definitions(mbedTLS INTERFACE
 	MBEDTLS_CONFIG_FILE="${CONFIG_MBEDTLS_CFG_FILE}"
 	)
 
-  target_include_directories(${IMAGE}mbedTLS INTERFACE
+  target_include_directories(mbedTLS INTERFACE
 	include
 	configs
 	)
@@ -94,14 +94,14 @@ if(CONFIG_MBEDTLS_BUILTIN)
   zephyr_library_sources(library/x509write_csr.c)
   zephyr_library_sources(library/xtea.c)
 
-  zephyr_library_link_libraries(${IMAGE}mbedTLS)
+  zephyr_library_link_libraries(mbedTLS)
 else()
   assert(CONFIG_MBEDTLS_LIBRARY "MBEDTLS was enabled, but neither BUILTIN or LIBRARY was selected.")
 
   # NB: CONFIG_MBEDTLS_LIBRARY is not regression tested and is
   # therefore susceptible to bit rot
 
-  target_include_directories(${IMAGE}mbedTLS INTERFACE
+  target_include_directories(mbedTLS INTERFACE
 	${CONFIG_MBEDTLS_INSTALL_PATH}
 	)
 
@@ -115,5 +115,5 @@ else()
   # after mbedtls_external on the linkers command line.
 endif()
 
-target_link_libraries(${IMAGE}mbedTLS INTERFACE ${IMAGE}zephyr_interface)
+target_link_libraries(mbedTLS INTERFACE zephyr_interface)
 endif()


### PR DESCRIPTION
This PR introduces the use of the new principle for creating multi image build.

It reverts the only nordic specific commit, so instead of merging this PR, I suggests we start following upstream SHA in our manifest.

----
This reverts commit 900c7eea92e45adba1067e044ec705d4541c84a5.

Commit is reverted as part of new multi image approach where ${IMAGE}
is no longer needed.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>